### PR TITLE
Remove pm2, Add npm-check-updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Docker-sails
 ============
 
-This Docker Container is installing the latest version of [Sails](http://sailsjs.org/) as well as [PM2](https://github.com/Unitech/PM2) to manage the app.
+This Docker Container is installing the latest version of [Sails.js](http://sailsjs.org/).
 This is still WIP and is meant to be rolled into [sane](https://github.com/artificialio/sane)/[sane-cli](https://github.com/artificialio/sane-cli) together with https://github.com/artificialio/docker-gen-nginx and [Fig](http://www.fig.sh/)
 
 sane-cli and fig together will give you an ecosystem, to get your fullstack app started immensly fast, make it completely customizable (you can easily choose MySQL/MongoDB/etc.) and deployable as-is.

--- a/node-0.10.32/Dockerfile
+++ b/node-0.10.32/Dockerfile
@@ -1,18 +1,13 @@
 ############################################################
-# Dockerfile to that builds on top of nginx to run
-# a sails app with PM2
+# Dockerfile for Sane-stack to run sails.js API application
 ############################################################
-
 
 FROM node:0.10.32-slim
 
 MAINTAINER Markus Padourek <markus@artificial.io>
 
-RUN npm install -g pm2@0.11.1 sails@0.10.5 grunt bower
+RUN npm install -g sails@0.10.5 grunt bower npm-check-updates
 RUN mkdir /server
-
-#installs nginx to /usr/sbin/nginx
-#conf file is at /etc/nginx/nginx.conf
 
 # Define mountable directories.
 VOLUME ["/server"]
@@ -20,9 +15,5 @@ VOLUME ["/server"]
 # Define working directory.
 WORKDIR /server
 
-# Define default command.
-#CMD ["pm2"]
-
 # Expose ports.
 EXPOSE 1337
-EXPOSE 3000

--- a/node-latest/Dockerfile
+++ b/node-latest/Dockerfile
@@ -1,18 +1,13 @@
 ############################################################
-# Dockerfile to that builds on top of nginx to run
-# a sails app with PM2
+# Dockerfile for Sane-stack to run sails.js API application
 ############################################################
-
 
 FROM node:0.11-slim
 
 MAINTAINER Markus Padourek <markus@artificial.io>
 
-RUN npm install -g pm2 sails grunt bower
+RUN npm install -g sails grunt bower npm-check-updates
 RUN mkdir /server
-
-#installs nginx to /usr/sbin/nginx
-#conf file is at /etc/nginx/nginx.conf
 
 # Define mountable directories.
 VOLUME ["/server"]
@@ -20,9 +15,5 @@ VOLUME ["/server"]
 # Define working directory.
 WORKDIR /server
 
-# Define default command.
-#CMD ["pm2"]
-
 # Expose ports.
 EXPOSE 1337
-EXPOSE 3000

--- a/node-stable/Dockerfile
+++ b/node-stable/Dockerfile
@@ -1,18 +1,13 @@
 ############################################################
-# Dockerfile to that builds on top of nginx to run
-# a sails app with PM2
+# Dockerfile for Sane-stack to run sails.js API application
 ############################################################
-
 
 FROM node:slim
 
 MAINTAINER Markus Padourek <markus@artificial.io>
 
-RUN npm install -g pm2 sails grunt bower
+RUN npm install -g sails grunt bower npm-check-updates
 RUN mkdir /server
-
-#installs nginx to /usr/sbin/nginx
-#conf file is at /etc/nginx/nginx.conf
 
 # Define mountable directories.
 VOLUME ["/server"]
@@ -20,9 +15,5 @@ VOLUME ["/server"]
 # Define working directory.
 WORKDIR /server
 
-# Define default command.
-#CMD ["pm2"]
-
 # Expose ports.
 EXPOSE 1337
-EXPOSE 3000


### PR DESCRIPTION
I think the default images should not have pm2.  If someone still wants pm2, perhaps create additional versions like `node-*-pm2`?
