### PR TITLE
nvm / npm not found fix

### DIFF
--- a/nvm-iojs-base/Dockerfile
+++ b/nvm-iojs-base/Dockerfile
@@ -58,4 +58,4 @@ RUN touch $HOME/.bashrc && \
     nvm alias default $NODE_VERSION
 
 # output version information
-CMD [ "npm", "version" ]
+CMD . /home/.bashrc && npm version 

--- a/nvm-iojs-latest/Dockerfile
+++ b/nvm-iojs-latest/Dockerfile
@@ -10,7 +10,7 @@ MAINTAINER Kris Williams <kris@kris.net>
 USER sane
 
 # install sails
-RUN bash -c ". /home/.bashrc && npm -g i sails@0.11 grunt bower pm2"
+RUN . /home/.bashrc && npm -g i sails@0.11 grunt bower pm2
 
 # Define mountable directories.
 VOLUME ["/server"]

--- a/nvm-iojs-latest/Dockerfile
+++ b/nvm-iojs-latest/Dockerfile
@@ -10,7 +10,7 @@ MAINTAINER Kris Williams <kris@kris.net>
 USER sane
 
 # install sails
-RUN npm -g i sails@0.11 grunt bower pm2
+RUN bash -c ". /home/.bashrc && npm -g i sails@0.11 grunt bower pm2"
 
 # Define mountable directories.
 VOLUME ["/server"]
@@ -21,4 +21,4 @@ WORKDIR /server
 # Expose ports.
 EXPOSE 1337
 
-CMD [ "npm", "start" ]
+CMD . /home/.bashrc && npm start


### PR DESCRIPTION
Include bash / .bashrc in calls so that nvm can actually do its job and provide a path to node / npm.
