### PR TITLE
iojs-nvm fix start command to work with non-interactive shell

### DIFF
--- a/nvm-iojs-base/Dockerfile
+++ b/nvm-iojs-base/Dockerfile
@@ -57,5 +57,11 @@ RUN touch $HOME/.bashrc && \
     nvm install $NODE_VERSION >> /dev/null 2>&1 && \
     nvm alias default $NODE_VERSION
 
-# output version information
-CMD [ "npm", "version" ]
+# default start command
+CMD \
+    # start nvm in non-interactive shell
+    source $NVM_DIR/nvm.sh && \
+    # install any node version present in /server/.nvmrc
+    nvm install >> /dev/null 2>&1 && \
+    # print version information and exit
+    npm version

--- a/nvm-iojs-latest/Dockerfile
+++ b/nvm-iojs-latest/Dockerfile
@@ -10,7 +10,9 @@ MAINTAINER Kris Williams <kris@kris.net>
 USER sane
 
 # install sails
-RUN npm -g i sails@0.11 grunt bower pm2
+RUN source $NVM_DIR/nvm.sh && \
+    npm -g i sails@0.11 grunt bower pm2 && \
+    npm cache clean
 
 # Define mountable directories.
 VOLUME ["/server"]

--- a/nvm-iojs-latest/Dockerfile
+++ b/nvm-iojs-latest/Dockerfile
@@ -21,4 +21,11 @@ WORKDIR /server
 # Expose ports.
 EXPOSE 1337
 
-CMD [ "npm", "start" ]
+# default start command
+CMD \
+    # start nvm in non-interactive shell
+    source $NVM_DIR/nvm.sh && \
+    # install any node version present in /server/.nvmrc
+    nvm install >> /dev/null 2>&1 && \
+    # run start as indicated in package.json
+    npm start


### PR DESCRIPTION
CMD doesn't run bash interactively, so we need to invoke nvm manually.
- Added bonus, allow user to specify an .nvmrc file to select a node of their choosing.
